### PR TITLE
Fix bearish line placement

### DIFF
--- a/SMC HYBRID
+++ b/SMC HYBRID
@@ -109,9 +109,15 @@ push_pivot(arrType, arrValue, arrIndex, valType, val, idx) =>
     array.push(arrIndex, idx)
 
 f_drawLineLabel(idx, lvl, lstyle, lcolor, txt, labStyle, labSize, ext=extend.none) =>
-    float adjust = syminfo.mintick
-    float plotLevel = labStyle == label.style_label_up ? lvl + adjust :\
-                      labStyle == label.style_label_down ? lvl - adjust : lvl
+    float adjust    = syminfo.mintick
+    float openLvl   = ta.valuewhen(bar_index == idx, open, 0)
+    float closeLvl  = ta.valuewhen(bar_index == idx, close, 0)
+    float bodyHigh  = math.max(openLvl, closeLvl)
+    float bodyLow   = math.min(openLvl, closeLvl)
+    float baseLevel = labStyle == label.style_label_up ? bodyHigh :
+                      labStyle == label.style_label_down ? bodyLow : lvl
+    float plotLevel = labStyle == label.style_label_up ? baseLevel + adjust :\
+                      labStyle == label.style_label_down ? baseLevel - adjust : lvl
     line.new(idx, plotLevel, bar_index, plotLevel, style=lstyle, color=lcolor, extend=ext)
     label.new((idx + bar_index) / 2, plotLevel, text=txt, color=color.rgb(0,0,0,100),
               textcolor=lcolor, style=labStyle, size=labSize)


### PR DESCRIPTION
## Summary
- adjust `f_drawLineLabel` to base levels on candle body

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68728a69253c8325b9ef955045694df8